### PR TITLE
fix joystick steering bug

### DIFF
--- a/Assets/Standard Assets/Vehicles/Car/Scripts/Steering.cs
+++ b/Assets/Standard Assets/Vehicles/Car/Scripts/Steering.cs
@@ -81,7 +81,7 @@ namespace UnityStandardAssets.Vehicles.Car
 
 				// reset
 				mouse_hold = false;
-                H = 0;
+				H = CrossPlatformInputManager.GetAxis ("Horizontal");
             }
 				
         }


### PR DESCRIPTION
Currently you can't use the joystick to steer the car. This fixes that. related to : https://github.com/udacity/self-driving-car-sim/issues/8